### PR TITLE
Hide dockerfile from binder

### DIFF
--- a/.github/workflows/reproduce-figures.yml
+++ b/.github/workflows/reproduce-figures.yml
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build and test inside container
-      run: docker build -t testimage docker
+      run: docker build -f docker/Dockerfile -t testimage .

--- a/.github/workflows/reproduce-figures.yml
+++ b/.github/workflows/reproduce-figures.yml
@@ -15,4 +15,4 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build and test inside container
-      run: docker build -t testimage .
+      run: docker build -t testimage docker

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ subdirectory. Where required, the notebooks will import this extra functionality
 
 ## Execution in a Docker container
 
-This repository also contains a [Dockerfile](Dockerfile) to create the required software environment in a container. The container will also automatically run all notebooks that reproduce figures. Figures are not automatically transferred back to the host system.
+This repository also contains a [Dockerfile](docker/Dockerfile) to create the required software environment in a container. The container will also automatically run all notebooks that reproduce figures. Figures are not automatically transferred back to the host system.
 
 ## License
 

--- a/apt.txt
+++ b/apt.txt
@@ -1,0 +1,1 @@
+libgl1-mesa-glx

--- a/apt.txt
+++ b/apt.txt
@@ -1,2 +1,0 @@
-libgl1-mesa-glx
-xvfb

--- a/apt.txt
+++ b/apt.txt
@@ -1,1 +1,2 @@
 libgl1-mesa-glx
+xvfb

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,4 +1,5 @@
 Dockerfile
+docker
 .dockerignore
 .git
 .gitignore

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,7 +1,0 @@
-Dockerfile
-docker
-.dockerignore
-.git
-.gitignore
-.github
-README

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ USER root
 # xvfb required for pyvista in notebook for Fig. 1
 RUN apt-get -y update && apt-get install -y git libgl1-mesa-glx xvfb && rm -rf /var/lib/apt/lists/*
 
-ADD .. /tmp/
+ADD . /tmp/
 RUN chown -R $MAMBA_USER .
 
 USER $MAMBA_USER

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ USER root
 # xvfb required for pyvista in notebook for Fig. 1
 RUN apt-get -y update && apt-get install -y git libgl1-mesa-glx xvfb && rm -rf /var/lib/apt/lists/*
 
-ADD . /tmp/
+ADD .. /tmp/
 RUN chown -R $MAMBA_USER .
 
 USER $MAMBA_USER


### PR DESCRIPTION
Binder uses the `Dockerfile` and ignores `environment.yml` when there is a Dockerfile in the root directory. However, our Dockerfile does not meet the requirements to be used on Binder and is only meant for use outside Binder.

Moving the files to a subdirectory solves the problem.